### PR TITLE
fix: #14728 usunięcie filtra stepstone.pl

### DIFF
--- a/polish-adblock-filters/adblock.txt
+++ b/polish-adblock-filters/adblock.txt
@@ -3594,7 +3594,6 @@ zywiecinfo.pl##.promoted
 ||static.wizaz.pl/system/kwc/promo/kwc_promo_box_*.html$subdocument
 ||statics.d404.pl/bundles/spoonsite/$image,domain=~motocaina.pl
 ||statics.tarsago.pl/$object-subrequest,domain=meczelive.tv|mecze24.pl
-||stepstone.pl^
 ||stg.wp.pl^$subdocument
 ||studentnews.pl/img/ban/b*.jpg$image
 ||superfilm.pl/*source=admedia&model=pop$popup


### PR DESCRIPTION
Filtr uniemożliwia normalne korzystanie ze strony

